### PR TITLE
Missing prefix after backward slash causing issue on installation files

### DIFF
--- a/language/nb-NO.json
+++ b/language/nb-NO.json
@@ -2,6 +2,6 @@
   "libraryStrings": {
     "example": "2 + 2 = 4\n0 * 4 = 4\n\n:Scandinavian city\nOslo is the capital of Norway\nOslo is the capital of Sweden\nOslo is the capital of Island",
     "warning": "Warning! If you change the tasks in the textual editor all rich text formatting(incl. line breaks) will be removed.",
-    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix \"
+    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix \n"
   }
 }

--- a/language/nb-NO.json
+++ b/language/nb-NO.json
@@ -2,6 +2,6 @@
   "libraryStrings": {
     "example": "2 + 2 = 4\n0 * 4 = 4\n\n:Scandinavian city\nOslo is the capital of Norway\nOslo is the capital of Sweden\nOslo is the capital of Island",
     "warning": "Warning! If you change the tasks in the textual editor all rich text formatting(incl. line breaks) will be removed.",
-    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix \n"
+    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix  \" : \""
   }
 }

--- a/language/nn.json
+++ b/language/nn.json
@@ -2,6 +2,6 @@
   "libraryStrings": {
     "example": "2 + 2 = 4\n0 * 4 = 4\n\n:Scandinavian city\nOslo is the capital of Norway\nOslo is the capital of Sweden\nOslo is the capital of Island",
     "warning": "Warning! If you change the tasks in the textual editor all rich text formatting(incl. line breaks) will be removed.",
-    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix \"
+    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix \n"
   }
 }

--- a/language/nn.json
+++ b/language/nn.json
@@ -2,6 +2,6 @@
   "libraryStrings": {
     "example": "2 + 2 = 4\n0 * 4 = 4\n\n:Scandinavian city\nOslo is the capital of Norway\nOslo is the capital of Sweden\nOslo is the capital of Island",
     "warning": "Warning! If you change the tasks in the textual editor all rich text formatting(incl. line breaks) will be removed.",
-    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix \n"
+    "helpText": "Write each statement on a separate line.\nUse an empty line to separate sets of statements.\nFirst statement is always correct.\nIf there is a tip - it is written on the first line with the prefix  \" : \""
   }
 }


### PR DESCRIPTION
This PR contains a fix for missing n after backward slash for newline on the translation files for nn.json and nb-NO.json